### PR TITLE
Bump version and enhance ICarryManager with new methods

### DIFF
--- a/CarryOnLib.csproj
+++ b/CarryOnLib.csproj
@@ -3,7 +3,7 @@
 
 		<AssemblyTitle>CarryOnLib</AssemblyTitle>
 		<Authors>NerdScurvy</Authors>
-		<Version>1.0.0-pre.1</Version>
+		<Version>1.0.0-pre.2</Version>
 
 		<Description>CarryOn extension library</Description>
 		<RepositoryUrl>https://github.com/NerdScurvy/CarryOnLib</RepositoryUrl>

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -25,7 +25,7 @@ async function setVersion() {
 
     try {
         await new Promise((resolve, reject) => {
-            gulp.src('./modinfo.json')
+            gulp.src('./resources/modinfo.json')
                 .pipe(replace(/"version"\s*:\s*".*?"/, `"version": "${modVersion}"`))
                 .pipe(replace(/"(.*?)"\s*:\s*"(.*?)"/g, (match, dep, ver) => {
                     if (dependencies.hasOwnProperty(dep)) {

--- a/resources/modinfo.json
+++ b/resources/modinfo.json
@@ -2,7 +2,7 @@
 	"type": "Code",
 	"name": "CarryOnLib",
 	"modid": "carryonlib",
-	"version": "1.0.0-pre.1",
+	"version": "1.0.0-pre.2",
 
 	"description": "Library for the CarryOn mod",
 	"website": "https://github.com/NerdScurvy/CarryOnLib",

--- a/src/API/Common/Interfaces/ICarriedTransformGroupResolver.cs
+++ b/src/API/Common/Interfaces/ICarriedTransformGroupResolver.cs
@@ -7,8 +7,6 @@ namespace CarryOn.API.Common.Interfaces
     {
         string ResolverCode { get; }
 
-        int Priority { get; }
-
         bool TryResolve(ICoreAPI api, CarriedBlock carried, string baseGroup, out CarriedGroupResolution resolution);
 
         /// <summary>

--- a/src/API/Common/Interfaces/ICarryManager.cs
+++ b/src/API/Common/Interfaces/ICarryManager.cs
@@ -278,8 +278,9 @@ namespace CarryOn.API.Common.Interfaces
         /// <summary>
         /// Registers a carried-render transform resolver.
         /// </summary>
+        /// <param name="modId">Owning mod id for the resolver registration.</param>
         /// <param name="resolver">The resolver to register.</param>
-        void RegisterTransformGroupResolver(ICarriedTransformGroupResolver resolver);
+        void RegisterTransformGroupResolver(string modId, ICarriedTransformGroupResolver resolver);
 
         /// <summary>
         /// Attempts to get a registered carried-render transform resolver by code.
@@ -288,6 +289,14 @@ namespace CarryOn.API.Common.Interfaces
         /// <param name="resolver">The resolver instance when found.</param>
         /// <returns>True if the resolver was found; otherwise false.</returns>
         bool TryGetTransformGroupResolver(string resolverCode, out ICarriedTransformGroupResolver resolver);
+
+        /// <summary>
+        /// Attempts to get resolver registration metadata by resolver code.
+        /// </summary>
+        /// <param name="resolverCode">The resolver code to look up.</param>
+        /// <param name="registration">The resolver registration when found.</param>
+        /// <returns>True if the resolver registration was found; otherwise false.</returns>
+        bool TryGetTransformGroupResolverRegistration(string resolverCode, out RegisteredTransformGroupResolver registration);
 
         /// <summary>
         /// Unregisters a previously registered carried-render transform resolver.
@@ -300,7 +309,7 @@ namespace CarryOn.API.Common.Interfaces
         /// Returns all currently registered carried-render transform resolvers.
         /// </summary>
         /// <returns>An ordered read-only list of registered resolvers.</returns>
-        IReadOnlyList<ICarriedTransformGroupResolver> GetTransformGroupResolvers();
+        IReadOnlyList<RegisteredTransformGroupResolver> GetTransformGroupResolvers();
 
         /// <summary>
         /// Checks if the block is carryable.

--- a/src/API/Common/Interfaces/ICarryManager.cs
+++ b/src/API/Common/Interfaces/ICarryManager.cs
@@ -277,10 +277,17 @@ namespace CarryOn.API.Common.Interfaces
 
         /// <summary>
         /// Registers a carried-render transform resolver.
-        /// Higher-priority resolvers run first.
         /// </summary>
         /// <param name="resolver">The resolver to register.</param>
         void RegisterTransformGroupResolver(ICarriedTransformGroupResolver resolver);
+
+        /// <summary>
+        /// Attempts to get a registered carried-render transform resolver by code.
+        /// </summary>
+        /// <param name="resolverCode">The resolver code to look up.</param>
+        /// <param name="resolver">The resolver instance when found.</param>
+        /// <returns>True if the resolver was found; otherwise false.</returns>
+        bool TryGetTransformGroupResolver(string resolverCode, out ICarriedTransformGroupResolver resolver);
 
         /// <summary>
         /// Unregisters a previously registered carried-render transform resolver.

--- a/src/API/Common/Models/CarryCode.cs
+++ b/src/API/Common/Models/CarryCode.cs
@@ -103,6 +103,7 @@ namespace CarryOn.API.Common.Models
                 public static string BarrelKey { get; } = "Barrel";
                 public static string BookshelfKey { get; } = "Bookshelf";
                 public static string BunchOCandlesKey { get; } = "BunchOCandles";
+                public static string CabinetKey { get; } = "Cabinet";
                 public static string ChandelierKey { get; } = "Chandelier";
                 public static string ChestTrunkKey { get; } = "ChestTrunk";
                 public static string ChestKey { get; } = "Chest";

--- a/src/API/Common/Models/CarryOnConfig.cs
+++ b/src/API/Common/Models/CarryOnConfig.cs
@@ -13,6 +13,7 @@ namespace CarryOn.API.Common.Models
         public bool Barrel { get; set; } = true;
         public bool Bookshelf { get; set; }
         public bool BunchOCandles { get; set; }
+        public bool Cabinet { get; set; } = true;
         public bool Chandelier { get; set; }
         public bool ChestTrunk { get; set; }
         public bool Chest { get; set; } = true;
@@ -265,6 +266,7 @@ namespace CarryOn.API.Common.Models
             carryables.SetBool(ConfigKey.Carryables.BunchOCandlesKey, Carryables.BunchOCandles);
             carryables.SetBool(ConfigKey.Carryables.ChandelierKey, Carryables.Chandelier);
             carryables.SetBool(ConfigKey.Carryables.ChestTrunkKey, Carryables.ChestTrunk);
+            carryables.SetBool(ConfigKey.Carryables.CabinetKey, Carryables.Cabinet);
             carryables.SetBool(ConfigKey.Carryables.ChestKey, Carryables.Chest);
             carryables.SetBool(ConfigKey.Carryables.ClutterKey, Carryables.Clutter);
             carryables.SetBool(ConfigKey.Carryables.CrateKey, Carryables.Crate);
@@ -359,6 +361,7 @@ namespace CarryOn.API.Common.Models
                 config.Carryables.Barrel = carryables.GetBool(ConfigKey.Carryables.BarrelKey);
                 config.Carryables.Bookshelf = carryables.GetBool(ConfigKey.Carryables.BookshelfKey);
                 config.Carryables.BunchOCandles = carryables.GetBool(ConfigKey.Carryables.BunchOCandlesKey);
+                config.Carryables.Cabinet = carryables.GetBool(ConfigKey.Carryables.CabinetKey);
                 config.Carryables.Chandelier = carryables.GetBool(ConfigKey.Carryables.ChandelierKey);
                 config.Carryables.ChestTrunk = carryables.GetBool(ConfigKey.Carryables.ChestTrunkKey);
                 config.Carryables.Chest = carryables.GetBool(ConfigKey.Carryables.ChestKey);

--- a/src/API/Common/Models/CarryOnConfig.cs
+++ b/src/API/Common/Models/CarryOnConfig.cs
@@ -41,7 +41,6 @@ namespace CarryOn.API.Common.Models
     public class CarryablesOnBackConfig
     {
         public bool Barrel { get; set; } = true;
-        public bool ChestLabeled { get; set; } = true;
         public bool ChestTrunk { get; set; }
         public bool Chest { get; set; } = true;
         public bool Crate { get; set; }

--- a/src/API/Common/Models/RegisteredTransformGroupResolver.cs
+++ b/src/API/Common/Models/RegisteredTransformGroupResolver.cs
@@ -1,0 +1,13 @@
+using CarryOn.API.Common.Interfaces;
+
+namespace CarryOn.API.Common.Models
+{
+    public sealed class RegisteredTransformGroupResolver
+    {
+        public string ModId { get; init; }
+
+        public string ResolverCode { get; init; }
+
+        public ICarriedTransformGroupResolver Resolver { get; init; }
+    }
+}

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "modVersion": "1.0.0-pre.1",
+  "modVersion": "1.0.0-pre.2",
   "dependencies": {
     "game": "1.22.0"
   }


### PR DESCRIPTION
This pull request introduces several enhancements and updates, primarily focused on improving the transform group resolver registration system and adding support for a new carryable item. It also updates version numbers across the project to `1.0.0-pre.2`. The most significant changes are grouped below:

### Transform Group Resolver System Enhancements

* The `ICarryManager` interface now requires a `modId` when registering a transform group resolver, and provides new methods to retrieve resolvers and their registration metadata by code. The return type for retrieving all resolvers has also changed to include registration metadata via the new `RegisteredTransformGroupResolver` class. [[1]](diffhunk://#diff-d52346c86974643ee2ea31ca4ee59f1ab7a47d68d60dbb3181334e025c31fb0bL280-R299) [[2]](diffhunk://#diff-d52346c86974643ee2ea31ca4ee59f1ab7a47d68d60dbb3181334e025c31fb0bL296-R312) [[3]](diffhunk://#diff-099e214a8235cc401eeea1414da18bfa26f669633109d61feb50372b193319f5R1-R13)
* The `Priority` property was removed from the `ICarriedTransformGroupResolver` interface, simplifying the resolver contract.

### Carryables Configuration Updates

* Added support for a new carryable item, `Cabinet`, including its configuration, serialization, and deserialization in `CarryOnConfig` and related classes. [[1]](diffhunk://#diff-993358e5f225a36c6e1af0f16ee4147c04734c0367f58ccd6f6309631c99d55cR106) [[2]](diffhunk://#diff-522f998b415d5aecb4b4a0a77b613456459c03dd07e8ea5f36077a5179f5a6edR16) [[3]](diffhunk://#diff-522f998b415d5aecb4b4a0a77b613456459c03dd07e8ea5f36077a5179f5a6edR269) [[4]](diffhunk://#diff-522f998b415d5aecb4b4a0a77b613456459c03dd07e8ea5f36077a5179f5a6edR364)
* Removed the `ChestLabeled` property from the `CarryablesOnBackConfig` class.

### Version and Metadata Updates

* Updated the mod version to `1.0.0-pre.2` in `CarryOnLib.csproj`, `modinfo.json`, and `version.json`. Also updated the path to `modinfo.json` in the build script. [[1]](diffhunk://#diff-3d6949a197dfc245331685e090729623ae20870eff7e6a02b70772cc25da4e12L6-R6) [[2]](diffhunk://#diff-72185534b39456dc67b49f38af48686100c5f8b000a31f39e4c7dafb20fdc4f5L5-R5) [[3]](diffhunk://#diff-093664cc0c7cf4a76165141e93265eeb139f655bbee8105ed3ee2534a612354cL2-R2) [[4]](diffhunk://#diff-25789e3ba4c2adf4a68996260eb693a441b4a834c38b76167a120f0b51b969f7L28-R28)