### PR TITLE
Bump version to 1.0.0-pre.3 in project files

### DIFF
--- a/CarryOnLib.csproj
+++ b/CarryOnLib.csproj
@@ -3,7 +3,7 @@
 
 		<AssemblyTitle>CarryOnLib</AssemblyTitle>
 		<Authors>NerdScurvy</Authors>
-		<Version>1.0.0-pre.2</Version>
+		<Version>1.0.0-pre.3</Version>
 
 		<Description>CarryOn extension library</Description>
 		<RepositoryUrl>https://github.com/NerdScurvy/CarryOnLib</RepositoryUrl>

--- a/resources/modinfo.json
+++ b/resources/modinfo.json
@@ -2,7 +2,7 @@
 	"type": "Code",
 	"name": "CarryOnLib",
 	"modid": "carryonlib",
-	"version": "1.0.0-pre.2",
+	"version": "1.0.0-pre.3",
 
 	"description": "Library for the CarryOn mod",
 	"website": "https://github.com/NerdScurvy/CarryOnLib",

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "modVersion": "1.0.0-pre.2",
+  "modVersion": "1.0.0-pre.3",
   "dependencies": {
     "game": "1.22.0"
   }


### PR DESCRIPTION
This pull request updates the version of the CarryOnLib mod from `1.0.0-pre.2` to `1.0.0-pre.3` across all relevant files to ensure consistency in versioning.

Version updates:

* Updated the version number in the `.csproj` project file to `1.0.0-pre.3` (`CarryOnLib.csproj`).
* Updated the version field in the mod metadata file to `1.0.0-pre.3` (`resources/modinfo.json`).
* Updated the `modVersion` in `version.json` to `1.0.0-pre.3`.