### PR TITLE
Feature/hailmary

### DIFF
--- a/src/API/Common/Models/CarryCode.cs
+++ b/src/API/Common/Models/CarryCode.cs
@@ -100,6 +100,12 @@ namespace CarryOn.API.Common.Models
 
             }
 
+            public static class DropOnDamage
+            {
+                public static string EnabledKey { get; } = "Enabled";
+                public static string DamageThresholdKey { get; } = "DamageThreshold";
+            }
+
             public static class Interactables
             {
                 public static string DoorKey { get; } = "Door";

--- a/src/API/Common/Models/CarryCode.cs
+++ b/src/API/Common/Models/CarryCode.cs
@@ -104,6 +104,7 @@ namespace CarryOn.API.Common.Models
             {
                 public static string EnabledKey { get; } = "Enabled";
                 public static string DamageThresholdKey { get; } = "DamageThreshold";
+                public static string DropRangeKey { get; } = "DropRange";
             }
 
             public static class Interactables

--- a/src/API/Common/Models/CarryOnConfig.cs
+++ b/src/API/Common/Models/CarryOnConfig.cs
@@ -97,7 +97,7 @@ namespace CarryOn.API.Common.Models
         public bool Enabled { get; set; } = true;
 
         [TreeValue("DamageThreshold")]
-        public float DamageThreshold { get; set; } = 0f;
+        public float DamageThreshold { get; set; } = 1.0f;
 
         [TreeValue("DropRange")]
         public int DropRange { get; set; } = 2;

--- a/src/API/Common/Models/CarryOnConfig.cs
+++ b/src/API/Common/Models/CarryOnConfig.cs
@@ -91,6 +91,15 @@ namespace CarryOn.API.Common.Models
         public CarrySlotSpeedConfig SlotDefaults { get; set; } = new CarrySlotSpeedConfig();
     }
 
+    public class DropOnDamageConfig
+    {
+        [TreeValue("Enabled")]
+        public bool Enabled { get; set; } = true;
+
+        [TreeValue("DamageThreshold")]
+        public float DamageThreshold { get; set; } = 0f;
+    }
+
     public class CarryOptionsConfig
     {
         [TreeValue("AllowSprintWhileCarrying")]           public bool AllowSprintWhileCarrying { get; set; } = false;
@@ -116,6 +125,7 @@ namespace CarryOn.API.Common.Models
                 ? mode : BackpackSelectionMode.LastFound;
 
         public WalkSpeedOverridesConfig WalkSpeedOverrides { get; set; } = new WalkSpeedOverridesConfig();
+        public DropOnDamageConfig DropOnDamage { get; set; } = new DropOnDamageConfig();
 
         [JsonExtensionData(ReadData = true, WriteData = false)]
         internal Dictionary<string, JToken>? Legacy { get; set; }
@@ -308,6 +318,7 @@ namespace CarryOn.API.Common.Models
         {
             var tree = (TreeAttribute)TreeSerializer.ToTree(CarryOptions);
             tree["WalkSpeedOverrides"] = ToWalkSpeedOverridesTree(CarryOptions.WalkSpeedOverrides);
+            tree["DropOnDamage"] = TreeSerializer.ToTree(CarryOptions.DropOnDamage);
             return tree;
         }
 
@@ -317,6 +328,7 @@ namespace CarryOn.API.Common.Models
 
             TreeSerializer.FromTree(tree, carryOptions);
             carryOptions.WalkSpeedOverrides = FromWalkSpeedOverridesTree(tree["WalkSpeedOverrides"] as ITreeAttribute);
+            carryOptions.DropOnDamage = FromDropOnDamageTree(tree["DropOnDamage"] as ITreeAttribute);
         }
 
         private static ITreeAttribute ToWalkSpeedOverridesTree(WalkSpeedOverridesConfig overrides)
@@ -434,6 +446,16 @@ namespace CarryOn.API.Common.Models
             }
 
             return speed;
+        }
+
+        private static DropOnDamageConfig FromDropOnDamageTree(ITreeAttribute? tree)
+        {
+            var config = new DropOnDamageConfig();
+            if (tree != null)
+            {
+                TreeSerializer.FromTree(tree, config);
+            }
+            return config;
         }
     }
 }

--- a/src/API/Common/Models/CarryOnConfig.cs
+++ b/src/API/Common/Models/CarryOnConfig.cs
@@ -98,6 +98,9 @@ namespace CarryOn.API.Common.Models
 
         [TreeValue("DamageThreshold")]
         public float DamageThreshold { get; set; } = 0f;
+
+        [TreeValue("DropRange")]
+        public int DropRange { get; set; } = 2;
     }
 
     public class CarryOptionsConfig


### PR DESCRIPTION
This pull request introduces a new "Drop On Damage" feature to the carry options configuration, allowing items to be dropped when the carrier takes damage above a configurable threshold. The changes add configuration models, serialization support, and constants for this feature.

**Drop On Damage feature:**

* Added a new `DropOnDamageConfig` class with properties for enabling/disabling the feature, setting a damage threshold, and specifying the drop range. (`src/API/Common/Models/CarryOnConfig.cs`)
* Integrated `DropOnDamageConfig` into the main `CarryOptionsConfig` class, so it can be configured per carry option. (`src/API/Common/Models/CarryOnConfig.cs`)
* Added serialization and deserialization logic for `DropOnDamageConfig` in the `ToCarryOptionsTree` and `FromCarryOptionsTree` methods, including a helper method for deserialization. (`src/API/Common/Models/CarryOnConfig.cs`) [[1]](diffhunk://#diff-522f998b415d5aecb4b4a0a77b613456459c03dd07e8ea5f36077a5179f5a6edR324) [[2]](diffhunk://#diff-522f998b415d5aecb4b4a0a77b613456459c03dd07e8ea5f36077a5179f5a6edR334) [[3]](diffhunk://#diff-522f998b415d5aecb4b4a0a77b613456459c03dd07e8ea5f36077a5179f5a6edR453-R462)

**Constants and keys:**

* Introduced a new static class `DropOnDamage` inside `CarryOptions`, containing string constants for the new configuration keys. (`src/API/Common/Models/CarryCode.cs`)