### PR TITLE
Bump version to 1.0.0-pre.7 and update interface for nullable support

### DIFF
--- a/CarryOnLib.csproj
+++ b/CarryOnLib.csproj
@@ -3,7 +3,7 @@
 
 		<AssemblyTitle>CarryOnLib</AssemblyTitle>
 		<Authors>NerdScurvy</Authors>
-		<Version>1.0.0-pre.5</Version>
+		<Version>1.0.0-pre.7</Version>
 
 		<Description>CarryOn extension library</Description>
 		<RepositoryUrl>https://github.com/NerdScurvy/CarryOnLib</RepositoryUrl>

--- a/resources/modinfo.json
+++ b/resources/modinfo.json
@@ -2,7 +2,7 @@
 	"type": "Code",
 	"name": "CarryOnLib",
 	"modid": "carryonlib",
-	"version": "1.0.0-pre.5",
+	"version": "1.0.0-pre.7",
 
 	"description": "Library for the CarryOn mod",
 	"website": "https://github.com/NerdScurvy/CarryOnLib",

--- a/src/API/Common/Interfaces/ICarryableTransfer.cs
+++ b/src/API/Common/Interfaces/ICarryableTransfer.cs
@@ -7,13 +7,13 @@ namespace CarryOn.API.Common.Interfaces
     {
         bool IsTransferEnabled(ICoreAPI api);
 
-        bool CanPutCarryable(IPlayer player, BlockEntity blockEntity, int index, ItemStack itemStack, ITreeAttribute blockEntityData, out float? transferDelay, out string failureCode, out string onScreenErrorMessage);
+        bool CanPutCarryable(IPlayer player, BlockEntity blockEntity, int index, ItemStack itemStack, ITreeAttribute? blockEntityData, out float? transferDelay, out string failureCode, out string onScreenErrorMessage);
 
         bool CanTakeCarryable(IPlayer player, BlockEntity blockEntity, int index, out float? transferDelay, out string failureCode, out string onScreenErrorMessage);
 
-        bool TryPutCarryable(IPlayer player, BlockEntity blockEntity, int index, ItemStack itemstack, ITreeAttribute blockEntityData, out string failureCode, out string onScreenErrorMessage);
+        bool TryPutCarryable(IPlayer player, BlockEntity blockEntity, int index, ItemStack itemstack, ITreeAttribute? blockEntityData, out string failureCode, out string onScreenErrorMessage);
 
-        bool TryTakeCarryable(IPlayer player, BlockEntity blockEntity, int index, out ItemStack itemstack, out ITreeAttribute blockEntityData, out string failureCode, out string onScreenErrorMessage);
+        bool TryTakeCarryable(IPlayer player, BlockEntity blockEntity, int index, out ItemStack itemstack, out ITreeAttribute? blockEntityData, out string failureCode, out string onScreenErrorMessage);
 
         bool IsBlockCarryAllowed(IPlayer player, BlockSelection selection);
 

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "modVersion": "1.0.0-pre.5",
+  "modVersion": "1.0.0-pre.7",
   "dependencies": {
     "game": "1.22.0"
   }


### PR DESCRIPTION
This pull request updates the CarryOnLib project to version 1.0.0-pre.7 and introduces a breaking change to the `ICarryableTransfer` interface by making the `blockEntityData` parameter nullable in several methods. This update improves the flexibility of the API when handling cases where `blockEntityData` may be absent.

**Version updates:**
* Bumped the version from `1.0.0-pre.5` to `1.0.0-pre.7` in `CarryOnLib.csproj`, `modinfo.json`, and `version.json` to reflect the new release. [[1]](diffhunk://#diff-3d6949a197dfc245331685e090729623ae20870eff7e6a02b70772cc25da4e12L6-R6) [[2]](diffhunk://#diff-72185534b39456dc67b49f38af48686100c5f8b000a31f39e4c7dafb20fdc4f5L5-R5) [[3]](diffhunk://#diff-093664cc0c7cf4a76165141e93265eeb139f655bbee8105ed3ee2534a612354cL2-R2)

**API changes:**
* Updated the `ICarryableTransfer` interface in `ICarryableTransfer.cs` to make the `blockEntityData` parameter nullable (`ITreeAttribute?`) in the `CanPutCarryable`, `TryPutCarryable`, and `TryTakeCarryable` methods, allowing for scenarios where block entity data may not be present.…hod signatures for nullable support