### PR TITLE
Feature/prerelease8 fix

### DIFF
--- a/src/Utility/CarriedBlockTreeSerializer.cs
+++ b/src/Utility/CarriedBlockTreeSerializer.cs
@@ -14,7 +14,6 @@ namespace CarryOn.Utility
             var tree = new TreeAttribute();
 
             var stack = carriedBlock.ItemStack;
-            if (stack == null) return null;
 
             tree.SetItemstack(AttributeKey.CarriedBlock.Stack, stack);
 

--- a/src/Utility/CarriedBlockTreeSerializer.cs
+++ b/src/Utility/CarriedBlockTreeSerializer.cs
@@ -41,6 +41,8 @@ namespace CarryOn.Utility
 
         public static CarriedBlock? Deserialize(ITreeAttribute tree, IWorldAccessor? world, CarrySlot slot = CarrySlot.Hands)
         {
+            if (world == null) return null;
+
             var stack = tree.GetItemstack(AttributeKey.CarriedBlock.Stack);
             if (stack?.Class != EnumItemClass.Block) return null;
             if (stack.Block == null)
@@ -79,6 +81,7 @@ namespace CarryOn.Utility
                 if (childStack?.Class != EnumItemClass.Block) continue;
                 if (childStack.Block == null)
                 {
+                    if (world == null) continue;
                     childStack.ResolveBlockOrItem(world);
                     if (childStack.Block == null) continue;
                 }


### PR DESCRIPTION
This pull request makes several improvements to the `CarriedBlockTreeSerializer` class to enhance null handling and robustness during serialization and deserialization of carried blocks.

Error handling and robustness improvements:

* Removed an early return in `Serialize` that would skip serialization if `ItemStack` is null, ensuring the method always returns a `TreeAttribute` even if the stack is missing.
* Added a null check for the `world` parameter in `Deserialize`, so the method returns null early if `world` is not provided, preventing potential null reference errors.
* Added a null check for `world` before resolving child blocks in the deserialization loop, ensuring the code does not attempt to resolve blocks if `world` is unavailable.